### PR TITLE
Changed logo to CC Black

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ import { Popover, Transition } from '@headlessui/react'
 import clsx from 'clsx'
 
 import { Container } from '@/components/Container'
-import avatarImage from '@/images/cute.png'
+import avatarImage from '@/images/theccblack.png'
 
 
 function CloseIcon(props: React.ComponentPropsWithoutRef<'svg'>) {


### PR DESCRIPTION
#11 Logo: switched Header logo to CC Black. Will work on transitioning this to the light version when dark mode is activated. 